### PR TITLE
Select PDF version policy. ATM is available only the export as PDF/A

### DIFF
--- a/Collabora-Office.admx
+++ b/Collabora-Office.admx
@@ -69,6 +69,9 @@
     <category name="FontSubstitutions" displayName="$(string.category_FontSubstitutions)">
       <parentCategory ref="Common" />
     </category>
+    <category name="PDFExport" displayName="$(string.category_PDFExport)">
+        <parentCategory ref="Common" />
+    </category>
     <category name="Writer" displayName="$(string.category_Writer)">
       <parentCategory ref="LibreOffice" />
     </category>
@@ -877,6 +880,21 @@
         <boolean id="Final" valueName="Final" />
       </elements>
     </policy>
+    <policy name="SelectPDFExport" class="Both" displayName="$(string.name_SelectPDFExport)" explainText="$(string.desc_SelectPDFExport)" presentation="$(presentation.SelectPDFExport)" key="Software\Policies\LibreOffice\org.openoffice.Office.Common\Filter\PDF\SelectPDFVersion">
+        <parentCategory ref="PDFExport" />
+        <supportedOn ref="supported_LibreOffice_4_2" />
+        <elements>
+          <boolean id="Value" valueName="Value">
+            <trueValue>
+              <string>true</string>
+            </trueValue>
+            <falseValue>
+              <string>false</string>
+            </falseValue>
+          </boolean>
+          <boolean id="Final" valueName="Final" />
+        </elements>
+      </policy>
     <policy name="UseSystemPrintDialog" class="Both" displayName="$(string.name_UseSystemPrintDialog)" explainText="$(string.desc_UseSystemPrintDialog)" presentation="$(presentation.UseSystemPrintDialog)" key="Software\Policies\LibreOffice\org.openoffice.Office.Common\Misc\UseSystemPrintDialog">
       <parentCategory ref="FileandPrintdialogs" />
       <supportedOn ref="supported_LibreOffice_4_2" />

--- a/en-US/Collabora-Office.adml
+++ b/en-US/Collabora-Office.adml
@@ -201,6 +201,10 @@ Default value: Macros enabled</string>
         <string id="name_FontPair_9">Font Pair 9</string>
         <string id="desc_FontPair">Defines font substitution pair</string>
 
+        <string id="category_PDFExport">PDF export</string>
+        <string id="name_SelectPDFExport">Select the preferred PDF export options</string>
+        <string id="desc_SelectPDFExport">Select the default PDF export options</string>
+
         <string id="category_Writer">Writer</string>
         <string id="desc_SaveAsFormat">Always save in this document format. Please note that only Open Document Format (ODF) guarantees full data integrity.</string>
         <string id="odt">ODF Text Document</string>
@@ -811,6 +815,10 @@ Set paths in path lists have to be separated by spaces.</string>
           <label>Substitute Font: </label>
         </textBox>
         <checkBox refId="Final">Final</checkBox>
+      </presentation>
+      <presentation id="SelectPDFExport">
+          <checkBox refId="Value">Export all the PDF as PDF/A</checkBox>
+          <checkBox refId="Final">Final</checkBox>
       </presentation>
     </presentationTable>
   </resources>


### PR DESCRIPTION
Signed-off-by: Marina Latini <marina@studiostorti.com>
New policy for selecting PDF/A as default 