### PR TITLE
Option to disable "allow this website to open a program" warning in IE

### DIFF
--- a/Collabora-Office.admx
+++ b/Collabora-Office.admx
@@ -288,6 +288,114 @@
         <boolean id="Final" valueName="Final" />
       </elements>
     </policy>
+    <policy name="OfficeURIOpenProgramNoWarn" class="Both" displayName="$(string.name_OfficeURIOpenProgramNoWarn)" explainText="$(string.desc_OfficeURIOpenProgramNoWarn)" key="Software\Policies\LibreOffice\OfficeURIOpenProgramNoWarn">
+      <parentCategory ref="LoadandSave" />
+      <supportedOn ref="supported_LibreOffice_5_3" />
+      <enabledList>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-word" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-powerpoint" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-excel" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-access" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\vnd.libreoffice.command" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-word" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-powerpoint" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-excel" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-access" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\vnd.libreoffice.command" valueName="WarnOnOpen">
+          <value>
+            <decimal value="0"/>
+          </value>
+        </item>
+      </enabledList>
+      <disabledList>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-word" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-powerpoint" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-excel" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\ms-access" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Microsoft\Internet Explorer\ProtocolExecute\vnd.libreoffice.command" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-word" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-powerpoint" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-excel" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\ms-access" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+        <item key="Software\Wow6432Node\Microsoft\Internet Explorer\ProtocolExecute\vnd.libreoffice.command" valueName="WarnOnOpen">
+          <value>
+            <decimal value="1"/>
+          </value>
+        </item>
+      </disabledList>
+    </policy>
     <policy name="AutoCorrect" class="Both" displayName="$(string.name_AutoCorrect)" explainText="$(string.PathListExplain)" presentation="$(presentation.AutoCorrect)" key="Software\Policies\LibreOffice\org.openoffice.Office.Paths\Paths\org.openoffice.Office.Paths:NamedPath['AutoCorrect']\WritePath">
       <parentCategory ref="Paths" />
       <supportedOn ref="supported_LibreOffice_5_3_49" />

--- a/en-US/Collabora-Office.adml
+++ b/en-US/Collabora-Office.adml
@@ -55,6 +55,13 @@ User unique attribute must correspond to the logged on user's Windows user name 
         <string id="desc_EditProperty">Specifies that the Properties dialog will appear every time you select the Save As command.</string>
         <string id="name_WarnAlienFormat">Warn the user when saving in a format different from ODF or default</string>
         <string id="desc_WarnAlienFormat">Specifies that the saving format is different from ODF or default.</string>
+        <string id="name_OfficeURIOpenProgramNoWarn">Don't warn about website opening the product when using Office URI</string>
+        <string id="desc_OfficeURIOpenProgramNoWarn">By default, when user clicks an Office URI link, Internet Explorer issues a warning that a website is trying to open a program, and asks for confirmation.
+
+This setting allows to disable the warning for Office URIs supported by the product (ms-word:, ms-excel:, ms-powerpoint:, ms-visio:, ms-access:, vnd.libreoffice.command:). Remember that this setting may be overridden by user if set in user settings.
+
+When enabled, no warning will be issued when user clicks a supported Office URI link.
+When disabled, the warning will be issued in this case.</string>
         <string id="name_HTMLExportBrowser">HTML export browser compatibility</string>
         <string id="desc_HTMLExportBrowser">Specifies the browser for which the HTML export should be optimized</string>
         <string id="IE">Internet Explorer</string>

--- a/es-ES/Collabora-Office.adml
+++ b/es-ES/Collabora-Office.adml
@@ -55,6 +55,13 @@ El atributo único de usuario debe corresponderse con el nombre de usuario de la
         <string id="desc_EditProperty">Especifica que el cuadro de diálogo Propiedades aparezca siempre que selecciona la orden Guardar como.</string>
         <string id="name_WarnAlienFormat">Alertar al usuario cuando se guarde en un formato distinto de ODF o del predeterminado</string>
         <string id="desc_WarnAlienFormat">Especifica que el formato de guardado sea distinto de ODF o del predeterminado.</string>
+        <string id="name_OfficeURIOpenProgramNoWarn">Don't warn about website opening the product when using Office URI</string>
+        <string id="desc_OfficeURIOpenProgramNoWarn">By default, when user clicks an Office URI link, Internet Explorer issues a warning that a website is trying to open a program, and asks for confirmation.
+
+This setting allows to disable the warning for Office URIs supported by the product (ms-word:, ms-excel:, ms-powerpoint:, ms-visio:, ms-access:, vnd.libreoffice.command:). Remember that this setting may be overridden by user if set in user settings.
+
+When enabled, no warning will be issued when user clicks a supported Office URI link.
+When disabled, the warning will be issued in this case.</string>
         <string id="name_HTMLExportBrowser">Compatibilidad con navegadores de exportación a HTML</string>
         <string id="desc_HTMLExportBrowser">Especifica para cuál navegador debe optimizarse la exportación a HTML</string>
         <string id="IE">Internet Explorer</string>

--- a/fr-FR/Collabora-Office.adml
+++ b/fr-FR/Collabora-Office.adml
@@ -57,6 +57,13 @@ User unique attribute must correspond to the logged on user's Windows user name 
         <string id="desc_EditProperty">Indique que la boîte de dialogue Propriétés s'affiche chaque fois que vous sélectionnez la commande Enregistrer sous.</string>
         <string id="name_WarnAlienFormat">Avertir l'utilisateur quand il sauvegarde un fichier dans format autre que .ODF ou celui défini par défaut.</string>
         <string id="desc_WarnAlienFormat">Indique si format d'enregistrement est différent de ODF ou par défaut.</string>
+        <string id="name_OfficeURIOpenProgramNoWarn">Don't warn about website opening the product when using Office URI</string>
+        <string id="desc_OfficeURIOpenProgramNoWarn">By default, when user clicks an Office URI link, Internet Explorer issues a warning that a website is trying to open a program, and asks for confirmation.
+
+This setting allows to disable the warning for Office URIs supported by the product (ms-word:, ms-excel:, ms-powerpoint:, ms-visio:, ms-access:, vnd.libreoffice.command:). Remember that this setting may be overridden by user if set in user settings.
+
+When enabled, no warning will be issued when user clicks a supported Office URI link.
+When disabled, the warning will be issued in this case.</string>
         <string id="name_HTMLExportBrowser">Compatibilité d'exportation avec les navigateurs HTML</string>
         <string id="desc_HTMLExportBrowser">Spécifie le navigateur pour lequel l'exportation HTML doit être optimisée</string>
         <string id="IE">Internet Explorer</string>

--- a/hu-HU/Collabora-Office.adml
+++ b/hu-HU/Collabora-Office.adml
@@ -55,6 +55,13 @@ User unique attribute must correspond to the logged on user's Windows user name 
         <string id="desc_EditProperty">Megadja, hogy a Mentés másként parancs kiválasztásakor mindig jelenjen meg a Tulajdonságok párbeszédablak.</string>
         <string id="name_WarnAlienFormat">Figyelmeztesse a felhasználót az ODF-től vagy az alapértelmezettől eltérő formátumban mentéskor.</string>
         <string id="desc_WarnAlienFormat">Megadja, hogy a mentési formátum eltér-e az ODF-től vagy az alapértelmezettől.</string>
+        <string id="name_OfficeURIOpenProgramNoWarn">Don't warn about website opening the product when using Office URI</string>
+        <string id="desc_OfficeURIOpenProgramNoWarn">By default, when user clicks an Office URI link, Internet Explorer issues a warning that a website is trying to open a program, and asks for confirmation.
+
+This setting allows to disable the warning for Office URIs supported by the product (ms-word:, ms-excel:, ms-powerpoint:, ms-visio:, ms-access:, vnd.libreoffice.command:). Remember that this setting may be overridden by user if set in user settings.
+
+When enabled, no warning will be issued when user clicks a supported Office URI link.
+When disabled, the warning will be issued in this case.</string>
         <string id="name_HTMLExportBrowser">HTML-export böngészőkompatibilitása</string>
         <string id="desc_HTMLExportBrowser">Megadja, hogy melyik böngészőre legyen a HTML-export optimalizálva</string>
         <string id="IE">Internet Explorer</string>

--- a/it-IT/Collabora-Office.adml
+++ b/it-IT/Collabora-Office.adml
@@ -57,6 +57,13 @@ L'attributo univoco dell'utente deve corrispondere al nome utente di Windows sen
         <string id="desc_EditProperty">Specifica che la finestra di dialogo Proprietà sarà visualizzata ogni volta che si seleziona il comando Salva con nome.</string>
         <string id="name_WarnAlienFormat">Avvisa se il salvataggio non è nel formato ODF o nel formato predefinito</string>
         <string id="desc_WarnAlienFormat">Indica che il formato di salvataggio è differente da ODF o dal predefinito</string>
+        <string id="name_OfficeURIOpenProgramNoWarn">Don't warn about website opening the product when using Office URI</string>
+        <string id="desc_OfficeURIOpenProgramNoWarn">By default, when user clicks an Office URI link, Internet Explorer issues a warning that a website is trying to open a program, and asks for confirmation.
+
+This setting allows to disable the warning for Office URIs supported by the product (ms-word:, ms-excel:, ms-powerpoint:, ms-visio:, ms-access:, vnd.libreoffice.command:). Remember that this setting may be overridden by user if set in user settings.
+
+When enabled, no warning will be issued when user clicks a supported Office URI link.
+When disabled, the warning will be issued in this case.</string>
         <string id="name_HTMLExportBrowser">Compatibilità del browser per l'esportazione HTML</string>
         <string id="desc_HTMLExportBrowser">Specifica il browser per cui ottimizzare l'esportazone in HTML</string>
         <string id="IE">Internet Explorer</string>


### PR DESCRIPTION
The option uses WarnOnOpen setting located under user's or computer's
SOFTWARE\Microsoft\Internet Explorer\ProtocolExecute, as described in
https://blogs.msdn.microsoft.com/ieinternals/2011/07/13/understanding-protocols/

This is a security-sensitive setting. As mentioned in the aforementioned
article, "for security reasons suppressing this prompt is generally
discouraged".

Since there's no way to enforce a multi-value setting outside of GPO
registry key, it's possible for a user (or a program) to change this
value after being set by GPO. Thus, the setting is rather to set a
"default" rather than to guarantee behaviour.