### PR TITLE
Add AllowOverrideLocking settings

### DIFF
--- a/Collabora-Office.admx
+++ b/Collabora-Office.admx
@@ -853,6 +853,21 @@
         <boolean id="Final" valueName="Final" />
       </elements>
     </policy>
+    <policy name="AllowOverrideLocking" class="User" displayName="$(string.name_AllowOverrideLocking)" explainText="$(string.desc_AllowOverrideLocking)" presentation="$(presentation.AllowOverrideLocking)" key="Software\Policies\LibreOffice\org.openoffice.Office.Common\Misc\AllowOverrideLocking">
+      <parentCategory ref="General" />
+      <supportedOn ref="supported_LibreOffice_7_0" />
+      <elements>
+        <boolean id="Value" valueName="Value">
+          <trueValue>
+            <string>true</string>
+          </trueValue>
+          <falseValue>
+            <string>false</string>
+          </falseValue>
+        </boolean>
+        <boolean id="Final" valueName="Final" />
+      </elements>
+    </policy>
     <policy name="ConvertToGreyscales" class="Both" displayName="$(string.name_ConvertToGreyscales)" explainText="$(string.desc_ConvertToGreyscales)" presentation="$(presentation.ConvertToGreyscales)" key="Software\Policies\LibreOffice\org.openoffice.Office.Common\Print\Option\Printer\ConvertToGreyscales">
       <parentCategory ref="Print" />
       <supportedOn ref="supported_LibreOffice_4_2" />

--- a/cs-CZ/Collabora-Office.adml
+++ b/cs-CZ/Collabora-Office.adml
@@ -30,6 +30,8 @@
       <string id="category_General">Obecné</string>
       <string id="name_UseSystemFileDialog">Použít systémový souborový dialog</string>
       <string id="desc_UseSystemFileDialog">Determines if Windows' file and folder picker should be used. If false, the built-in platform independent file/folder picker implementations will be used.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">Pomozte vylepšit LibreOffice</string>
       <string id="desc_CollectUsageInformation">Shromažďovat údaje o používání a posílat je do The Document Foundation</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -903,6 +905,10 @@ Set paths in path lists have to be separated by spaces.</string>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Použít systémový souborový dialog</checkBox>
         <checkBox refId="Final">Konečné</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Shromažďovat údaje o používání a posílat je do The Document Foundation</checkBox>

--- a/de-DE/Collabora-Office.adml
+++ b/de-DE/Collabora-Office.adml
@@ -30,6 +30,8 @@
       <string id="category_General">Allgemein</string>
       <string id="name_UseSystemFileDialog">Dateidialoge des Systems verwenden</string>
       <string id="desc_UseSystemFileDialog">Legt fest, ob der Windows Dialog zum Wählen von Dateien und Ordnern (z.B. beim "Speichern unter") genutzt werden soll. Falls nicht, werden integrierte plattformübergreifende Implementierungen genutzt.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">Mithelfen, LibreOffice zu verbessern</string>
       <string id="desc_CollectUsageInformation">Nutzungsdaten sammeln und an die The Document Foundation senden</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -904,6 +906,10 @@ Pfade in Pfadlisten müssen durch Leerzeichen getrennt werden.</string>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Dateidialoge des Systems verwenden</checkBox>
         <checkBox refId="Final">Gesperrt</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Nutzungsdaten sammeln und an die The Document Foundation senden</checkBox>

--- a/en-US/Collabora-Office.adml
+++ b/en-US/Collabora-Office.adml
@@ -30,6 +30,8 @@
       <string id="category_General">General</string>
       <string id="name_UseSystemFileDialog">Use System File Dialog</string>
       <string id="desc_UseSystemFileDialog">Determines if Windows' file and folder picker should be used. If false, the built-in platform independent file/folder picker implementations will be used.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">Help improve LibreOffice</string>
       <string id="desc_CollectUsageInformation">Collect usage data and send it to The Document Foundation</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -903,6 +905,10 @@ Set paths in path lists have to be separated by spaces.</string>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Use System File Dialog</checkBox>
         <checkBox refId="Final">Final</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Collect usage data and send it to The Document Foundation</checkBox>

--- a/es-ES/Collabora-Office.adml
+++ b/es-ES/Collabora-Office.adml
@@ -30,6 +30,8 @@
       <string id="category_General">Generales</string>
       <string id="name_UseSystemFileDialog">Usar diálogo de apertura de archivos del sistema</string>
       <string id="desc_UseSystemFileDialog">Determina si se debe utilizar el selector de archivos y carpetas de Windows. Si el valor es falso, se empleará el cuadro de diálogo multiplataforma incorporado.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">Ayudar a mejorar LibreOffice</string>
       <string id="desc_CollectUsageInformation">Recopilar datos de uso y enviarlos a The Document Foundation</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -903,6 +905,10 @@ Las rutas en listas de rutas se deben separar con espacios.</string>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Usar diálogo de apertura de archivos del sistema</checkBox>
         <checkBox refId="Final">Final</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Recopilar datos de uso y enviarlos a The Document Foundation</checkBox>

--- a/fr-FR/Collabora-Office.adml
+++ b/fr-FR/Collabora-Office.adml
@@ -32,6 +32,8 @@
       <string id="category_General">Général</string>
       <string id="name_UseSystemFileDialog">Utilisez la boîte de dialogue fichier du système</string>
       <string id="desc_UseSystemFileDialog">Spécifie si les boîtes de dialogue de Windows permettent d'ouvrir et d'enregistrer des documents. Si ce n'est pas le cas, ce sont les boîtes de dialogue de LibreOffice qui seront utilisées.</string>
+      <string id="name_AllowOverrideLocking">Autorisez le contournement du verrouillage d'un document</string>
+      <string id="desc_AllowOverrideLocking">Détermine si l'utilisateur peut contourner le verrouillage de document dans LibreOffice/Collabora Office. Si désactivé et que le document est déjà ouvert par un autre utilisateur, l'utilisateur actuel ne pourra l'ouvrir qu'en copie ou en mode lecture seule.</string>
       <string id="name_CollectUsageInformation">Aider à améliorer LibreOffice</string>
       <string id="desc_CollectUsageInformation">Collecter des données d'usage et les envoyer à The Document Foundation</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -919,6 +921,10 @@ Les chemins définis dans une liste doivent être séparés par des espaces.</st
       </presentation>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Utilisez la boîte de dialogue fichier du système</checkBox>
+        <checkBox refId="Final">Verrouiller le paramètre</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Activer ou désactiver le contournement du verrouillage</checkBox>
         <checkBox refId="Final">Verrouiller le paramètre</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">

--- a/hu-HU/Collabora-Office.adml
+++ b/hu-HU/Collabora-Office.adml
@@ -30,6 +30,8 @@
       <string id="category_General">Általános</string>
       <string id="name_UseSystemFileDialog">A rendszer fájl párbeszédablakának használata</string>
       <string id="desc_UseSystemFileDialog">Megadja, hogy a Windows fájl- és mappaválasztó ablakát kell-e használni. Ha hamis, a beépített platformfüggetlen fájl- és mappaválasztó ablakok lesznek használva.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">Segítsen a LibreOffice tökéletesítésében</string>
       <string id="desc_CollectUsageInformation">Felhasználási adatok gyűjtése és elküldése a The Document Foundationnek</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -904,6 +906,10 @@ Set paths in path lists have to be separated by spaces.</string>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">A rendszer fájl párbeszédablakának használata</checkBox>
         <checkBox refId="Final">Végleges</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Felhasználási adatok gyűjtése és elküldése a The Document Foundationnek</checkBox>

--- a/it-IT/Collabora-Office.adml
+++ b/it-IT/Collabora-Office.adml
@@ -32,6 +32,8 @@
       <string id="category_General">Generale</string>
       <string id="name_UseSystemFileDialog">Utilizza le finestre di dialogo di sistema</string>
       <string id="desc_UseSystemFileDialog">Specifica se vengono utilizzate le finestre di dialogo di apertura file e cartelle di Windows. Se falso, saranno utilizzate quelle implementate in LibreOffice.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">Aiutaci a migliorare LibreOffice</string>
       <string id="desc_CollectUsageInformation">Raccogli i dati di utilizzo e inviali a The Document Foundation</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -906,6 +908,10 @@ I percorsi impostati nelle liste dei percorsi devono essere separati da spazi.</
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Utilizza le finestre di dialogo di sistema</checkBox>
         <checkBox refId="Final">Finale</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Raccogli i dati di utilizzo e inviali a The Document Foundation</checkBox>

--- a/pt-BR/Collabora-Office.adml
+++ b/pt-BR/Collabora-Office.adml
@@ -30,6 +30,8 @@
       <string id="category_General">Geral</string>
       <string id="name_UseSystemFileDialog">Use a Caixa de Diálogo do Arquivo de Sistema</string>
       <string id="desc_UseSystemFileDialog">Determina se o seletor de arquivos e pastas do Windows deve ser usado. Se não,  a plataforma embutida independente de arquivos / pastas será usada.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">Ajude a melhorar o LibreOffice</string>
       <string id="desc_CollectUsageInformation">Colete dados de uso e envie-os para The Document Foundation</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -903,6 +905,10 @@ Set paths in path lists have to be separated by spaces.</string>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Use a Caixa de Diálogo do Arquivo de Sistema</checkBox>
         <checkBox refId="Final">Final</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Colete dados de uso e envie-os para The Document Foundation</checkBox>

--- a/tr-TR/Collabora-Office.adml
+++ b/tr-TR/Collabora-Office.adml
@@ -30,6 +30,8 @@
       <string id="category_General">Genel</string>
       <string id="name_UseSystemFileDialog">Sistem Dosya İletişim Penceresini Kullan</string>
       <string id="desc_UseSystemFileDialog">Windows'un dosya ve dizin seçicisinin kullanılması gerekip gerekmediğini belirler. Yanlışsa, yerleşik platformdan bağımsız dosya/dizin seçici uygulamaları kullanılacaktır.</string>
+      <string id="name_AllowOverrideLocking">Allow override document locking</string>
+      <string id="desc_AllowOverrideLocking">Specifies whether the user is allowed to override the document locking mechanism in LibreOffice/Collabora Office. If disabled and the document is already opened by another user, the current user can open a document only as a copy or in read only mode.</string>
       <string id="name_CollectUsageInformation">LibreOffice'i geliştirmeye yardımcı olun</string>
       <string id="desc_CollectUsageInformation">Kullanım verilerini toplayın ve The Document Foundation'a gönderin</string>
       <string id="name_ShowTipOfTheDay">Show Tip of the Day</string>
@@ -903,6 +905,10 @@ Set paths in path lists have to be separated by spaces.</string>
       <presentation id="UseSystemFileDialog">
         <checkBox refId="Value">Sistem Dosya İletişim Penceresini Kullan</checkBox>
         <checkBox refId="Final">Son</checkBox>
+      </presentation>
+      <presentation id="AllowOverrideLocking">
+        <checkBox refId="Value">Enable or disable override locking</checkBox>
+        <checkBox refId="Final">Prevent the user from changing this setting</checkBox>
       </presentation>
       <presentation id="CollectUsageInformation">
         <checkBox refId="Value">Kullanım verilerini toplayın ve The Document Foundation'a gönderin</checkBox>


### PR DESCRIPTION
This change introduces a setting that controls whether a user can override the document locking mechanism in LibreOffice/Collabora Office.
If disabled, and the document is already open by another user, the current user will only be able to open it as a copy or in read-only mode.